### PR TITLE
Basic Game, Player, & Venue API with an In-Memory Database

### DIFF
--- a/Model/Frame.cs
+++ b/Model/Frame.cs
@@ -19,6 +19,7 @@
 /// SOFTWARE.
 
 using System;
+using System.Text.Json.Serialization;
 
 namespace NinetyNine.Model
 {
@@ -30,6 +31,8 @@ namespace NinetyNine.Model
         public Guid FrameId { get; set; }
 
         public Guid GameId { get; set; }
+        
+        [JsonIgnore]
         public Game Game { get; set; }
 
         public bool BreakBonus { get; set; } = false;

--- a/Model/Game.cs
+++ b/Model/Game.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace NinetyNine.Model
 {
@@ -39,6 +40,7 @@ namespace NinetyNine.Model
         /// <summary>
         /// Gets/Sets the <see cref="NinetyNine.Model.Player"/> of this <see cref="Game"/>
         /// </summary>
+        [JsonIgnore]
         public Player Player { get; set; }
 
         /// <summary>

--- a/Model/Model.csproj
+++ b/Model/Model.csproj
@@ -10,4 +10,8 @@
       <AssemblyName>NinetyNine.Model</AssemblyName>
    </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="6.0.2" />
+  </ItemGroup>
+
 </Project>

--- a/Model/Player.cs
+++ b/Model/Player.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace NinetyNine.Model
 {
@@ -37,7 +38,7 @@ namespace NinetyNine.Model
         public string LastName { get; set; } = String.Empty;
         public string FirstName { get; set; } = String.Empty;
         public string MiddleName { get; set; } = String.Empty;
-
+        [JsonIgnore]
         public List<Game> Games { get; set; } = new List<Game>();
     }
 }

--- a/NinetyNine.sln
+++ b/NinetyNine.sln
@@ -22,6 +22,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Presentation", "Presentatio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UI", "UI\UI.csproj", "{C56C8B27-C510-4270-85C4-1254C6D15B31}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services", "Services\Services.csproj", "{C5504345-5974-4E1D-8979-D28A820D79BC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{C56C8B27-C510-4270-85C4-1254C6D15B31}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C56C8B27-C510-4270-85C4-1254C6D15B31}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C56C8B27-C510-4270-85C4-1254C6D15B31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5504345-5974-4E1D-8979-D28A820D79BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5504345-5974-4E1D-8979-D28A820D79BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5504345-5974-4E1D-8979-D28A820D79BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5504345-5974-4E1D-8979-D28A820D79BC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NinetyNine.sln
+++ b/NinetyNine.sln
@@ -12,7 +12,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E388D797-8E26-4F2F-B8F8-FBC8962D09FD}"
 	ProjectSection(SolutionItems) = preProject
-		UI\NinetyNine.db = UI\NinetyNine.db
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Repository/LocalContext.cs
+++ b/Repository/LocalContext.cs
@@ -19,14 +19,24 @@
 /// SOFTWARE.
 
 using Microsoft.EntityFrameworkCore;
+using NinetyNine.Model;
 
 namespace NinetyNine.Repository
 {
     public class LocalContext : NinetyNineContext
     {
-        public LocalContext() : base("LocalDatabase") { }
+        public DbSet<Game> Games { get; set; }
+
+        public DbSet<Player> Players { get; set; }
+
+        public DbSet<Venue> Venues { get; set; }
+
+        public LocalContext() : base("LocalDatabase") 
+        {
+
+        }
 
         protected override void OnConfiguring(DbContextOptionsBuilder options)
-            => options.UseSqlite(@"Data Source=NinetyNine.db");
+            => options.UseInMemoryDatabase("NinetyNineDatabase");
     }
 }

--- a/Services/Controllers/GamesController.cs
+++ b/Services/Controllers/GamesController.cs
@@ -1,0 +1,60 @@
+using AutoFixture;
+using Microsoft.AspNetCore.Mvc;
+using NinetyNine.Model;
+
+namespace Services.Controllers;
+
+[ApiController]
+[Route("api/v0/[controller]")]
+public class GamesController : ControllerBase
+{
+    private static Fixture _fixture = new Fixture();
+
+    private IEnumerable<Game> _games;
+
+    public GamesController()
+    {
+        _fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
+            .ForEach(b => _fixture.Behaviors.Remove(b));
+        _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+        _games = _fixture.CreateMany<Game>(15);
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Game>>> GetGames()
+    {
+        return _games.ToArray();
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Game>> GetGame(Guid id)
+    {
+        return Ok();
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateGame(Guid id, Game game)
+    {
+        return NotFound();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Game>> CreateGame(Game newGame)
+    {
+
+        return Ok();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteGame(Guid Id)
+    {
+        var game = _games.FirstOrDefault(x => x.GameId == Id);
+
+        if (game == null)
+        {
+            return NotFound();
+        }
+        
+        return Ok();
+    }
+}

--- a/Services/Controllers/GamesController.cs
+++ b/Services/Controllers/GamesController.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NinetyNine.Model;
-using NinetyNine.Repository;
 
 namespace Services.Controllers;
 
@@ -10,9 +9,9 @@ namespace Services.Controllers;
 [Route("api/{v:apiVersion}/[controller]")]
 public class GamesController : ControllerBase
 {
-    private readonly LocalContext _context;
+    private readonly NinetyNineContext _context;
 
-    public GamesController(LocalContext dbContext)
+    public GamesController(NinetyNineContext dbContext)
     {
         _context = dbContext;
     }
@@ -66,7 +65,7 @@ public class GamesController : ControllerBase
     }
 
     [HttpPost]
-    public async Task<ActionResult<Game>> CreateGame(Game newGame)
+    public async Task<ActionResult<Game>> CreateGame([Bind("Players, LocationPlayed, WhenPlayed, TableSize, Frames")] Game newGame)
     {
         _context.Games.Add(newGame);
         await _context.SaveChangesAsync();

--- a/Services/Controllers/PlayersController.cs
+++ b/Services/Controllers/PlayersController.cs
@@ -1,0 +1,97 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NinetyNine.Model;
+using NinetyNine.Repository;
+
+namespace Services.Controllers;
+
+[ApiController]
+[ApiVersion("0.0")]
+[Route("api/{v:apiVersion}/[controller]")]
+public class PlayersController : ControllerBase
+{
+    private readonly LocalContext _context;
+
+    public PlayersController(LocalContext dbContext)
+    {
+        _context = dbContext;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Player>>> GetPlayers()
+    {
+        return await _context.Players.ToListAsync();
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Player>> GetPlayer(Guid id)
+    {
+        var player = await _context.Players.FindAsync(id);
+        
+        if (player == null)
+        {
+            return NotFound();
+        }
+        
+        return player;
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdatePlayer(Guid id, Player player)
+    {
+        if (id != player.PlayerId)
+        {
+            return BadRequest();
+        }
+
+        var oldPlayer= await _context.Players.FindAsync(id);
+
+        if (oldPlayer == null)
+        {
+            return NotFound();
+        }
+
+        oldPlayer = player;
+
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch (DbUpdateConcurrencyException) when (!PlayerExists(id))
+        {
+            return NotFound();
+        }
+
+        return NoContent();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Player>> CreatePlayer(Player newPlayer)
+    {
+        _context.Players.Add(newPlayer);
+        await _context.SaveChangesAsync();
+        
+        return CreatedAtAction(nameof(GetPlayer), new {id = newPlayer.PlayerId}, newPlayer);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeletePlayer(Guid id)
+    {
+        var player = await _context.Players.FindAsync(id);
+
+        if (player == null)
+        {
+            return NotFound();
+        }
+
+        _context.Players.Remove(player);
+        await _context.SaveChangesAsync();
+
+        return NoContent();
+    }
+
+    private bool PlayerExists(Guid id)
+    {
+        return _context.Players.Any(x => x.PlayerId == id);
+    }
+}

--- a/Services/Controllers/PlayersController.cs
+++ b/Services/Controllers/PlayersController.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NinetyNine.Model;
-using NinetyNine.Repository;
 
 namespace Services.Controllers;
 
@@ -10,9 +9,9 @@ namespace Services.Controllers;
 [Route("api/{v:apiVersion}/[controller]")]
 public class PlayersController : ControllerBase
 {
-    private readonly LocalContext _context;
+    private readonly NinetyNineContext _context;
 
-    public PlayersController(LocalContext dbContext)
+    public PlayersController(NinetyNineContext dbContext)
     {
         _context = dbContext;
     }

--- a/Services/Controllers/VenuesController.cs
+++ b/Services/Controllers/VenuesController.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NinetyNine.Model;
-using NinetyNine.Repository;
 
 namespace Services.Controllers;
 
@@ -10,9 +9,9 @@ namespace Services.Controllers;
 [Route("api/{v:apiVersion}/[controller]")]
 public class VenuesController : ControllerBase
 {
-    private readonly LocalContext _context;
+    private readonly NinetyNineContext _context;
 
-    public VenuesController(LocalContext dbContext)
+    public VenuesController(NinetyNineContext dbContext)
     {
         _context = dbContext;
     }

--- a/Services/Controllers/VenuesController.cs
+++ b/Services/Controllers/VenuesController.cs
@@ -1,0 +1,97 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NinetyNine.Model;
+using NinetyNine.Repository;
+
+namespace Services.Controllers;
+
+[ApiController]
+[ApiVersion("0.0")]
+[Route("api/{v:apiVersion}/[controller]")]
+public class VenuesController : ControllerBase
+{
+    private readonly LocalContext _context;
+
+    public VenuesController(LocalContext dbContext)
+    {
+        _context = dbContext;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Venue>>> GetVenues()
+    {
+        return await _context.Venues.ToListAsync();
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Venue>> GetVenue(Guid id)
+    {
+        var venue = await _context.Venues.FindAsync(id);
+        
+        if (venue == null)
+        {
+            return NotFound();
+        }
+        
+        return venue;
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateVenue(Guid id, Venue venue)
+    {
+        if (id != venue.VenueId)
+        {
+            return BadRequest();
+        }
+
+        var oldVenue= await _context.Venues.FindAsync(id);
+
+        if (oldVenue == null)
+        {
+            return NotFound();
+        }
+
+        oldVenue = venue;
+
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch (DbUpdateConcurrencyException) when (!VenueExists(id))
+        {
+            return NotFound();
+        }
+
+        return NoContent();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Venue>> CreateVenue(Venue newVenue)
+    {
+        _context.Venues.Add(newVenue);
+        await _context.SaveChangesAsync();
+        
+        return CreatedAtAction(nameof(GetVenue), new {id = newVenue.VenueId}, newVenue);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteVenue(Guid id)
+    {
+        var venue = await _context.Venues.FindAsync(id);
+
+        if (venue == null)
+        {
+            return NotFound();
+        }
+
+        _context.Venues.Remove(venue);
+        await _context.SaveChangesAsync();
+
+        return NoContent();
+    }
+
+    private bool VenueExists(Guid id)
+    {
+        return _context.Venues.Any(x => x.VenueId == id);
+    }
+}

--- a/Services/NinetyNineContext.cs
+++ b/Services/NinetyNineContext.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using NinetyNine.Model;
+
+namespace Services;
+
+public class NinetyNineContext : DbContext
+{
+    public NinetyNineContext(DbContextOptions<NinetyNineContext> options) :
+        base(options)
+    {}
+
+    public DbSet<Game> Games { get; set; }
+    
+    public DbSet<Player> Players { get; set; }
+    
+    public DbSet<Venue> Venues { get; set; }
+}

--- a/Services/Program.cs
+++ b/Services/Program.cs
@@ -1,0 +1,25 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/Services/Program.cs
+++ b/Services/Program.cs
@@ -1,3 +1,6 @@
+using Microsoft.AspNetCore.Mvc;
+using NinetyNine.Repository;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -6,6 +9,13 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddApiVersioning(x =>
+{
+    x.DefaultApiVersion = new ApiVersion(0, 0);
+    x.AssumeDefaultVersionWhenUnspecified = true;
+    x.ReportApiVersions = true;
+});
+builder.Services.AddDbContext<LocalContext>();
 
 var app = builder.Build();
 

--- a/Services/Program.cs
+++ b/Services/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
-using NinetyNine.Repository;
+using Microsoft.EntityFrameworkCore;
+using Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,7 +16,8 @@ builder.Services.AddApiVersioning(x =>
     x.AssumeDefaultVersionWhenUnspecified = true;
     x.ReportApiVersions = true;
 });
-builder.Services.AddDbContext<LocalContext>();
+builder.Services.AddDbContext<NinetyNineContext>(opt =>
+    opt.UseInMemoryDatabase("NinetyNine"));
 
 var app = builder.Build();
 

--- a/Services/Properties/launchSettings.json
+++ b/Services/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:14798",
+      "sslPort": 44326
+    }
+  },
+  "profiles": {
+    "Services": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7070;http://localhost:5003",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Services/Services.csproj
+++ b/Services/Services.csproj
@@ -8,11 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Model\Model.csproj" />
+    <ProjectReference Include="..\Repository\Repository.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Services/Services.csproj
+++ b/Services/Services.csproj
@@ -10,12 +10,12 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Model\Model.csproj" />
-    <ProjectReference Include="..\Repository\Repository.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Services/Services.csproj
+++ b/Services/Services.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Model\Model.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Services/appsettings.Development.json
+++ b/Services/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/Services/appsettings.json
+++ b/Services/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Added a services project with controllers for the Game, Player, and Venue APIs backed by an in-memory database for testing. Right now I did not want to use the repository project as I do not believe it is necessary until we decide on a permanent database and more detailed architecture. It also includes some changes to the model to prevent a circular reference issue with the JSON serialization. Right now I am not sure if this is the best way to handle it, but it serves the purpose for basic testing needs. 